### PR TITLE
update sabio url to get around broken redirect

### DIFF
--- a/cobrak/sabio_rk_functionality.py
+++ b/cobrak/sabio_rk_functionality.py
@@ -141,7 +141,7 @@ class SabioThread(threading.Thread):
         try:
             t0 = time()
             request = requests.post(
-                "http://sabiork.h-its.org/sabioRestWebServices/kineticlawsExportTsv",
+                "https://sabiork.h-its.org/sabioRestWebServices/kineticlawsExportTsv",
                 params=query,
                 timeout=120,
             )


### PR DESCRIPTION
Hi,
this package looks very interesting and well made, kudos! While playing around with it I noticed that the SABIO-rk webserver seems to be misconfigured:
```
% curl -I http://sabiork.h-its.org/sabioRestWebServices/kineticlawsExportTsv
HTTP/1.1 301 Moved Permanently
Date: Tue, 05 May 2026 12:15:49 GMT
Server: Apache/2.4.41 (Ubuntu)
Location: https://sabiork.h-its.orgsabioRestWebServices/kineticlawsExportTsv
Content-Type: text/html; charset=iso-8859-1
```

The HTTPS redirect is missing a slash, causing the request to fail. Better to connect directly to HTTPS anyway.